### PR TITLE
Wrap ZoneMRTCalculation

### DIFF
--- a/model/simulationtests/zonemrtcalculation.py
+++ b/model/simulationtests/zonemrtcalculation.py
@@ -1,0 +1,148 @@
+import openstudio
+from lib.baseline_model import BaselineModel
+
+model = BaselineModel()
+
+# make a 1 story, 100m X 50m, 5 zone core/perimeter building
+model.add_geometry(length=100, width=50, num_floors=1, floor_to_floor_height=4, plenum_height=1, perimeter_zone_depth=3)
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows(wwr=0.4, offset=1, application_type="Above Floor")
+
+# add thermostats
+model.add_thermostats(heating_setpoint=19, cooling_setpoint=26)
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions()
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type()
+
+# add design days to the model (Chicago)
+model.add_design_days()
+
+
+# In order to produce more consistent results between different runs,
+# we sort the spaces by names
+spaces = sorted(model.getSpaces(), key=lambda s: s.nameString())
+
+# Collapse all spaces into one thermal zone
+thermal_zone = spaces[0].thermalZone().get()
+for space in spaces:
+    z = space.thermalZone().get()
+    space.setThermalZone(thermal_zone)
+    if z != thermal_zone:
+        z.remove()
+thermal_zone.setName("5 spaces zone")
+if len(model.getThermalZones()) != 1:
+    raise ValueError("Expected a single Thermal Zone")
+if len(thermal_zone.spaces()) != len(spaces):
+    raise ValueError("Expected the Thermal Zone to have all spaces")
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows(wwr=0.4, offset=1, application_type="Above Floor")
+
+# create the zone property user view factors by surface name object
+# There are a number of preconditions you must meet:
+# * All People objects should be assigned directly to a space,
+# * All spaces should be assigned to the same Thermal Zone.
+# The Sum of the MRT Weighting Factors for all People objects in the same Thermal Zone must be < 1.0
+zonemrtcalc = thermal_zone.getZoneMRTCalculation()
+
+# create thermal comfort schedules
+workeffsch = openstudio.model.ScheduleConstant(model)
+workeffsch.setValue(0.5)
+cloinssch = openstudio.model.ScheduleConstant(model)
+cloinssch.setValue(0.5)
+airvelsch = openstudio.model.ScheduleConstant(model)
+airvelsch.setValue(0.5)
+
+# get all people in the zone
+peoples = []
+for space in spaces:
+    definition1 = openstudio.model.PeopleDefinition(model)
+    definition1.setNumberofPeople(1.0)
+    definition1.setMeanRadiantTemperatureCalculationType("EnclosureAveraged")
+    definition1.setThermalComfortModelType(0, "Fanger")
+
+    people1 = openstudio.model.People(definition1)
+    people1.setWorkEfficiencySchedule(workeffsch)
+    people1.setClothingInsulationSchedule(cloinssch)
+    people1.setAirVelocitySchedule(airvelsch)
+    people1.setSpace(space)
+    peoples.append(people1)
+
+    definition2 = openstudio.model.PeopleDefinition(model)
+    definition2.setNumberofPeople(1.0)
+    definition2.setMeanRadiantTemperatureCalculationType("EnclosureAveraged")  # SurfaceWeighted, AngleFactor not supported?
+    definition2.setThermalComfortModelType(0, "Pierce")
+
+    people2 = openstudio.model.People(definition2)
+    people2.setWorkEfficiencySchedule(workeffsch)
+    people2.setClothingInsulationSchedule(cloinssch)
+    people2.setAirVelocitySchedule(airvelsch)
+    people2.setSpace(space)
+    peoples.append(people2)
+
+# Extensible: MRT Weighting Factors for people
+
+people_one_mrt_weighting_factor = 0.37
+people_other_mrt_weighting_factor = (1 - people_one_mrt_weighting_factor) / (len(peoples) - 1)
+# people, mrt_weighting_factor
+mrt_weighting_factor_infos = []
+mrt_weighting_factor_infos.append([peoples[0], people_one_mrt_weighting_factor])
+for people in peoples[1:]:
+    mrt_weighting_factor_infos.append([people, people_other_mrt_weighting_factor])
+# # To add a group, you can use the convenience method
+# bool addMRTWeightingFactor(const People&, double mRTWeightingFactor)
+zonemrtcalc.addMRTWeightingFactor(mrt_weighting_factor_infos[0][0], mrt_weighting_factor_infos[0][1])
+
+# This will in turn actually use the helper class MRTWeightingFactor
+zonemrtcalc.addMRTWeightingFactor(
+    openstudio.model.MRTWeightingFactor(mrt_weighting_factor_infos[1][0], mrt_weighting_factor_infos[1][1])
+)
+
+# NOTE: if you call addMRTWeightingFactor with a People object that is already in the list, it will update the
+# MRTWeightingFactor value for that People object.
+
+if zonemrtcalc.numberofMRTWeightingFactors() != 2:
+    raise ValueError("Expected 2 MRT Weighting Factors")
+# This is a vector of MRTWeightingFactor
+if len(zonemrtcalc.mRTWeightingFactors()) != 2:
+    raise ValueError("Expected 2 MRT Weighting Factors")
+
+if zonemrtcalc.mRTWeightingFactorIndex(peoples[0]).get() != 0:
+    raise ValueError("Expected index 0 for peoples[0]")
+if zonemrtcalc.mRTWeightingFactorIndex(peoples[1]).get() != 1:
+    raise ValueError("Expected index 1 for peoples[1]")
+
+first_mrt_group = zonemrtcalc.mRTWeightingFactors()[0]
+# This returns an OptionalMRTWeightingFactor
+first_mrt_group_ = zonemrtcalc.getMRTWeightingFactor(0)
+if not first_mrt_group_.is_initialized():
+    raise ValueError("Expected the MRTWeightingFactor at index 0 to be initialized")
+if first_mrt_group.people() != first_mrt_group_.get().people():
+    raise ValueError("Expected the same People object")
+
+zonemrtcalc.removeMRTWeightingFactor(0)
+if zonemrtcalc.numberofMRTWeightingFactors() != 1:
+    raise ValueError("Expected 1 MRT Weighting Factor")
+if zonemrtcalc.numExtensibleGroups() != 1:
+    raise ValueError("Expected 1 extensible group")
+if zonemrtcalc.mRTWeightingFactorIndex(peoples[1]).get() != 0:
+    raise ValueError("Expected index 0 for peoples[1]")
+
+zonemrtcalc.removeAllMRTWeightingFactors()
+if zonemrtcalc.numberofMRTWeightingFactors() != 0:
+    raise ValueError("Expected 0 MRT Weighting Factors")
+if zonemrtcalc.numExtensibleGroups() != 0:
+    raise ValueError("Expected 0 extensible groups")
+
+# There is also a batch add
+mrt_groups = [openstudio.model.MRTWeightingFactor(g[0], g[1]) for g in mrt_weighting_factor_infos]
+zonemrtcalc.addMRTWeightingFactors(mrt_groups)
+if zonemrtcalc.numberofMRTWeightingFactors() != len(peoples):
+    raise ValueError("Expected as many MRT Weighting Factors as peoples")
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm(osm_save_directory=None, osm_name="in.osm")

--- a/model/simulationtests/zonemrtcalculation.rb
+++ b/model/simulationtests/zonemrtcalculation.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'openstudio'
+require_relative 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 1 story, 100m X 50m, 5 zone core/perimeter building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 1,
+                     'perimeter_zone_depth' => 3 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add ASHRAE System type 01, PTAC, Residential
+model.add_hvac({ 'ashrae_sys_num' => '01' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 24,
+                        'cooling_setpoint' => 28 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+thermal_zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+# assign mrt weighting factors to all people in a single thermal zone
+thermal_zone = thermal_zones[0]
+
+# create the zone property user view factors by surface name object
+zonemrtcalc = thermal_zone.getZoneMRTCalculation
+
+# get all spaces in the zone
+spaces = thermal_zone.spaces.sort_by { |s| s.name.to_s }
+
+# create thermal comfort schedules
+workeffsch = OpenStudio::Model::ScheduleConstant.new(model)
+workeffsch.setValue(0.5)
+cloinssch = OpenStudio::Model::ScheduleConstant.new(model)
+cloinssch.setValue(0.5)
+airvelsch = OpenStudio::Model::ScheduleConstant.new(model)
+airvelsch.setValue(0.5)
+
+# get all people in the zone
+peoples = []
+spaces.each do |space|
+  definition1 = OpenStudio::Model::PeopleDefinition.new(model)
+  definition1.setNumberofPeople(1.0)
+  definition1.setMeanRadiantTemperatureCalculationType("EnclosureAveraged")
+  definition1.setThermalComfortModelType(0, "Fanger")
+
+  people1 = OpenStudio::Model::People.new(definition1)
+  people1.setWorkEfficiencySchedule(workeffsch)
+  people1.setClothingInsulationSchedule(cloinssch)
+  people1.setAirVelocitySchedule(airvelsch)
+  people1.setSpace(space)
+  peoples << people1
+
+  definition2 = OpenStudio::Model::PeopleDefinition.new(model)
+  definition2.setNumberofPeople(1.0)
+  definition2.setMeanRadiantTemperatureCalculationType("EnclosureAveraged") # SurfaceWeighted, AngleFactor not supported?
+  definition2.setThermalComfortModelType(0, "Pierce")
+
+  people2 = OpenStudio::Model::People.new(definition2)
+  people2.setWorkEfficiencySchedule(workeffsch)
+  people2.setClothingInsulationSchedule(cloinssch)
+  people2.setAirVelocitySchedule(airvelsch)
+  people2.setSpace(space)
+  peoples << people2
+end
+
+# mrt weighting factors for people
+peoples = peoples.uniq.sort_by { |p| p.name.to_s }
+peoples.each do |people|
+  zonemrtcalc.addMRTWeightingFactor(people, 1.0 / peoples.size)
+end
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'in.osm' })

--- a/model/simulationtests/zonemrtcalculation.rb
+++ b/model/simulationtests/zonemrtcalculation.rb
@@ -59,8 +59,8 @@ peoples = []
 spaces.each do |space|
   definition1 = OpenStudio::Model::PeopleDefinition.new(model)
   definition1.setNumberofPeople(1.0)
-  definition1.setMeanRadiantTemperatureCalculationType("EnclosureAveraged")
-  definition1.setThermalComfortModelType(0, "Fanger")
+  definition1.setMeanRadiantTemperatureCalculationType('EnclosureAveraged')
+  definition1.setThermalComfortModelType(0, 'Fanger')
 
   people1 = OpenStudio::Model::People.new(definition1)
   people1.setWorkEfficiencySchedule(workeffsch)
@@ -71,8 +71,8 @@ spaces.each do |space|
 
   definition2 = OpenStudio::Model::PeopleDefinition.new(model)
   definition2.setNumberofPeople(1.0)
-  definition2.setMeanRadiantTemperatureCalculationType("EnclosureAveraged") # SurfaceWeighted, AngleFactor not supported?
-  definition2.setThermalComfortModelType(0, "Pierce")
+  definition2.setMeanRadiantTemperatureCalculationType('EnclosureAveraged') # SurfaceWeighted, AngleFactor not supported?
+  definition2.setThermalComfortModelType(0, 'Pierce')
 
   people2 = OpenStudio::Model::People.new(definition2)
   people2.setWorkEfficiencySchedule(workeffsch)

--- a/model/simulationtests/zonemrtcalculation.rb
+++ b/model/simulationtests/zonemrtcalculation.rb
@@ -18,12 +18,9 @@ model.add_windows({ 'wwr' => 0.4,
                     'offset' => 1,
                     'application_type' => 'Above Floor' })
 
-# add ASHRAE System type 01, PTAC, Residential
-model.add_hvac({ 'ashrae_sys_num' => '01' })
-
 # add thermostats
-model.add_thermostats({ 'heating_setpoint' => 24,
-                        'cooling_setpoint' => 28 })
+model.add_thermostats({ 'heating_setpoint' => 19,
+                        'cooling_setpoint' => 26 })
 
 # assign constructions from a local library to the walls/windows/etc. in the model
 model.set_constructions
@@ -35,16 +32,31 @@ model.set_space_type
 model.add_design_days
 
 # In order to produce more consistent results between different runs,
-# we sort the zones by names
-thermal_zones = model.getThermalZones.sort_by { |z| z.name.to_s }
-# assign mrt weighting factors to all people in a single thermal zone
-thermal_zone = thermal_zones[0]
+# we sort the spaces by names
+spaces = model.getSpaces.sort_by { |s| s.name.to_s }
+
+# Collapse all spaces into one thermal zone
+thermal_zone = spaces[0].thermalZone.get
+spaces.each do |space|
+  z = space.thermalZone.get
+  space.setThermalZone(thermal_zone)
+  z.remove if z != thermal_zone
+end
+thermal_zone.setName('5 spaces zone')
+raise if model.getThermalZones.size != 1
+raise if thermal_zone.spaces.size != spaces.size
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
 
 # create the zone property user view factors by surface name object
+# There are a number of preconditions you must meet:
+# * All People objects should be assigned directly to a space,
+# * All spaces should be assigned to the same Thermal Zone.
+# The Sum of the MRT Weighting Factors for all People objects in the same Thermal Zone must be < 1.0
 zonemrtcalc = thermal_zone.getZoneMRTCalculation
-
-# get all spaces in the zone
-spaces = thermal_zone.spaces.sort_by { |s| s.name.to_s }
 
 # create thermal comfort schedules
 workeffsch = OpenStudio::Model::ScheduleConstant.new(model)
@@ -82,11 +94,52 @@ spaces.each do |space|
   peoples << people2
 end
 
-# mrt weighting factors for people
-peoples = peoples.uniq.sort_by { |p| p.name.to_s }
-peoples.each do |people|
-  zonemrtcalc.addMRTWeightingFactor(people, 1.0 / peoples.size)
+# Extensible: MRT Weighting Factors for people
+
+people_one_mrt_weighting_factor = 0.37
+people_other_mrt_weighting_factor = (1 - people_one_mrt_weighting_factor) / (peoples.size - 1)
+# people, mrt_weighting_factor
+mrt_weighting_factor_infos = []
+mrt_weighting_factor_infos << [peoples[0], people_one_mrt_weighting_factor]
+peoples[1..-1].each do |people|
+  mrt_weighting_factor_infos << [people, people_other_mrt_weighting_factor]
 end
+# # To add a group, you can use the convenience method
+# bool addMRTWeightingFactor(const People&, double mRTWeightingFactor);
+zonemrtcalc.addMRTWeightingFactor(mrt_weighting_factor_infos[0][0], mrt_weighting_factor_infos[0][1])
+
+# This will in turn actually use the helper class MRTWeightingFactor
+zonemrtcalc.addMRTWeightingFactor(OpenStudio::Model::MRTWeightingFactor.new(mrt_weighting_factor_infos[1][0], mrt_weighting_factor_infos[1][1]))
+
+# NOTE: if you call addMRTWeightingFactor with a People object that is already in the list, it will update the
+# MRTWeightingFactor value for that People object.
+
+raise unless zonemrtcalc.numberofMRTWeightingFactors == 2
+# This is a vector of MRTWeightingFactor
+raise unless zonemrtcalc.mRTWeightingFactors.size == 2
+
+raise unless zonemrtcalc.mRTWeightingFactorIndex(peoples[0]).get == 0
+raise unless zonemrtcalc.mRTWeightingFactorIndex(peoples[1]).get == 1
+
+first_mrt_group = zonemrtcalc.mRTWeightingFactors.first
+# This returns an OptionalMRTWeightingFactor
+first_mrt_group_ = zonemrtcalc.getMRTWeightingFactor(0)
+raise unless first_mrt_group_.is_initialized
+raise unless first_mrt_group.people == first_mrt_group_.get.people
+
+zonemrtcalc.removeMRTWeightingFactor(0)
+raise unless zonemrtcalc.numberofMRTWeightingFactors == 1
+raise unless zonemrtcalc.numExtensibleGroups == 1
+raise unless zonemrtcalc.mRTWeightingFactorIndex(peoples[1]).get == 0
+
+zonemrtcalc.removeAllMRTWeightingFactors
+raise unless zonemrtcalc.numberofMRTWeightingFactors == 0
+raise unless zonemrtcalc.numExtensibleGroups == 0
+
+# There is also a batch add
+mrt_groups = mrt_weighting_factor_infos.map { |g| OpenStudio::Model::MRTWeightingFactor.new(g[0], g[1]) }
+zonemrtcalc.addMRTWeightingFactors(mrt_groups)
+raise unless zonemrtcalc.numberofMRTWeightingFactors == peoples.size
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -2307,6 +2307,15 @@ class ModelTests < Minitest::Test
     result = sim_test('zone_mixing.py')
   end
 
+  def test_zonemrtcalculation_rb
+    result = sim_test('zonemrtcalculation.rb')
+  end
+
+  # TODO: To be added in the next official release after: 3.11.0
+  # def test_zonemrtcalculation_osm
+  #   result = sim_test('zonemrtcalculation.osm')
+  # end
+
   def test_zoneventilation_windandstackopenarea_rb
     result = sim_test('zoneventilation_windandstackopenarea.rb')
   end

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -2311,6 +2311,10 @@ class ModelTests < Minitest::Test
     result = sim_test('zonemrtcalculation.rb')
   end
 
+  def test_zonemrtcalculation_py
+    result = sim_test('zonemrtcalculation.py')
+  end
+
   # TODO: To be added in the next official release after: 3.11.0
   # def test_zonemrtcalculation_osm
   #   result = sim_test('zonemrtcalculation.osm')


### PR DESCRIPTION
Pull request overview
---------------------

Companion PR:
* https://github.com/NatLabRockies/OpenStudio/pull/5649

Link to relevant GitHub Issue(s) if appropriate:

Link to the **Ubuntu 24.04 .deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.


----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.
<!---
> eg:
>
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following classes:
> * `AirTerminalSingleDuctConstantVolumeFourPipeBeam`
> * `CoilCoolingFourPipeBeam`
> * `CoilHeatingFourPipeBeam`
> * Additionally it explicitly tests for the existing class [TableMultiVariableLookUp](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/TableMultiVariableLookup.hpp)
-->

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [ ] with current develop (incude SHA):
         - [ ] The label `PendingOSM` has been added to this PR
         - [ ] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO: To be added in the next official release after: 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [ ] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [ ] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

 - [ ] **Object has been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**

----------------------------------------------------------------------------------------------------------

### Case 2: Fix for an existing test

Please include a link to the specific test you are modifying, and a description of the changes you have made and why they are required.

### Work Checklist

**The change:**
 - [ ] affects site kBTU results
 - [ ] does not affect total site kBTU results

**If it affects total site kBTU:**
 - [ ] Test has been run backwards (see [Instructions for Running Docker](https://github.com/NREL/OpenStudio-resources/blob/develop/doc/Instructions_Docker.md)) for all OpenStudio versions to update numbers
 - [ ] Changes did not make the test fail in older OpenStudio versions where it used to pass
 - [ ] Matching OSM has been replaced with the output of the ruby test for the oldest OpenStudio release where it passes.
 - [ ] All new/changed `out.osw` have been committed for official OpenStudio versions only

**Either way:**

 - [ ] **Ruby test is still stable**: when run multiple times on the same machine, it produces the same total site kBTU.
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign Terminals to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

 - [ ] **If relevant, new fields that can be autosized have been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**


----------------------------------------------------------------------------------------------------------

### Case 3: New test for an already-existing model API class

Please include which class(es) you are adding a test to specifically test for as it was currently not being tested for.
Include a link to the OpenStudio model classes themselves.

> eg:
>
> This pull request adds missing tests for the following classes:
> *  [AvailabilibityManagerDifferentialThermostat](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerDifferentialThermostat.hpp)
> *  [AvailabilibityManagerHighTemperatureTurnOff](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerHighTemperatureTurnOff.hpp)
> *  [AvailabilibityManagerHighTemperatureTurnOn](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerHighTemperatureTurnOn.hpp)

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] **Test has been run backwards** (see [Instructions for Running Docker](https://github.com/NREL/OpenStudio-resources/blob/develop/doc/Instructions_Docker.md)) for all OpenStudio versions
 - [ ] **A Matching OSM test** has been added with the output of the ruby test for the oldest OpenStudio release where it passes (include OpenStudio Version)

 - [ ] **Ruby test is stable** in the last OpenStudio version: when run multiple times on the same machine, it produces the same total site kBTU.
    - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

 - [ ] **Object has been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**

----------------------------------------------------------------------------------------------------------

### Case 4: Other

Please be as explicit as possible about the changes you have made, and why they are warranted.


----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
