### PR TITLE
Wrap ComfortViewFactorAngles

### DIFF
--- a/model/simulationtests/comfortviewfactorangles.rb
+++ b/model/simulationtests/comfortviewfactorangles.rb
@@ -51,12 +51,6 @@ model.add_windows({ 'wwr' => 0.4,
                     'offset' => 1,
                     'application_type' => 'Above Floor' })
 
-# There are a number of preconditions you must meet:
-# * All People objects should be assigned directly to a space,
-# * All spaces should be assigned to the same Thermal Zone.
-# The Sum of the MRT Weighting Factors for all People objects in the same Thermal Zone must be < 1.0
-zonemrtcalc = thermal_zone.getZoneMRTCalculation
-
 # create thermal comfort schedules
 workeffsch = OpenStudio::Model::ScheduleConstant.new(model)
 workeffsch.setValue(0.5)
@@ -65,12 +59,28 @@ cloinssch.setValue(0.5)
 airvelsch = OpenStudio::Model::ScheduleConstant.new(model)
 airvelsch.setValue(0.5)
 
-# get all people in the zone
-peoples = []
 spaces.each do |space|
+  surfaces = []
+  sub_surfaces = []
+  space.surfaces.each do |surface|
+    surfaces << surface
+    surface.subSurfaces.each do |sub_surface|
+      sub_surfaces << sub_surface
+    end
+  end
+
+  surfaces = surfaces.uniq.sort_by { |s| s.name.to_s }
+  sub_surfaces = sub_surfaces.uniq.sort_by { |s| s.name.to_s }
+
+  comfortview = OpenStudio::Model::ComfortViewFactorAngles.new(model)
+  (surfaces + sub_surfaces).each do |surface|
+    comfortview.addAngleFactor(surface, 1.0 / (surfaces.size + sub_surfaces.size))
+  end
+
   definition1 = OpenStudio::Model::PeopleDefinition.new(model)
   definition1.setNumberofPeople(1.0)
-  definition1.setMeanRadiantTemperatureCalculationType('EnclosureAveraged')
+  definition1.setMeanRadiantTemperatureCalculationType('SurfaceWeighted')
+  definition1.setSurfaceNameAngleFactorListName(surfaces[0])
   definition1.setThermalComfortModelType(0, 'Fanger')
 
   people1 = OpenStudio::Model::People.new(definition1)
@@ -78,11 +88,11 @@ spaces.each do |space|
   people1.setClothingInsulationSchedule(cloinssch)
   people1.setAirVelocitySchedule(airvelsch)
   people1.setSpace(space)
-  peoples << people1
 
   definition2 = OpenStudio::Model::PeopleDefinition.new(model)
   definition2.setNumberofPeople(1.0)
-  definition2.setMeanRadiantTemperatureCalculationType('EnclosureAveraged')
+  definition2.setMeanRadiantTemperatureCalculationType('AngleFactor')
+  definition2.setSurfaceNameAngleFactorListName(comfortview)
   definition2.setThermalComfortModelType(0, 'Pierce')
 
   people2 = OpenStudio::Model::People.new(definition2)
@@ -90,55 +100,7 @@ spaces.each do |space|
   people2.setClothingInsulationSchedule(cloinssch)
   people2.setAirVelocitySchedule(airvelsch)
   people2.setSpace(space)
-  peoples << people2
 end
-
-# Extensible: MRT Weighting Factors for people
-
-people_one_mrt_weighting_factor = 0.37
-people_other_mrt_weighting_factor = (1 - people_one_mrt_weighting_factor) / (peoples.size - 1)
-# people, mrt_weighting_factor
-mrt_weighting_factor_infos = []
-mrt_weighting_factor_infos << [peoples[0], people_one_mrt_weighting_factor]
-peoples[1..-1].each do |people|
-  mrt_weighting_factor_infos << [people, people_other_mrt_weighting_factor]
-end
-# # To add a group, you can use the convenience method
-# bool addMRTWeightingFactor(const People&, double mRTWeightingFactor);
-zonemrtcalc.addMRTWeightingFactor(mrt_weighting_factor_infos[0][0], mrt_weighting_factor_infos[0][1])
-
-# This will in turn actually use the helper class MRTWeightingFactor
-zonemrtcalc.addMRTWeightingFactor(OpenStudio::Model::MRTWeightingFactor.new(mrt_weighting_factor_infos[1][0], mrt_weighting_factor_infos[1][1]))
-
-# NOTE: if you call addMRTWeightingFactor with a People object that is already in the list, it will update the
-# MRTWeightingFactor value for that People object.
-
-raise unless zonemrtcalc.numberofMRTWeightingFactors == 2
-# This is a vector of MRTWeightingFactor
-raise unless zonemrtcalc.mRTWeightingFactors.size == 2
-
-raise unless zonemrtcalc.mRTWeightingFactorIndex(peoples[0]).get == 0
-raise unless zonemrtcalc.mRTWeightingFactorIndex(peoples[1]).get == 1
-
-first_mrt_group = zonemrtcalc.mRTWeightingFactors.first
-# This returns an OptionalMRTWeightingFactor
-first_mrt_group_ = zonemrtcalc.getMRTWeightingFactor(0)
-raise unless first_mrt_group_.is_initialized
-raise unless first_mrt_group.people == first_mrt_group_.get.people
-
-zonemrtcalc.removeMRTWeightingFactor(0)
-raise unless zonemrtcalc.numberofMRTWeightingFactors == 1
-raise unless zonemrtcalc.numExtensibleGroups == 1
-raise unless zonemrtcalc.mRTWeightingFactorIndex(peoples[1]).get == 0
-
-zonemrtcalc.removeAllMRTWeightingFactors
-raise unless zonemrtcalc.numberofMRTWeightingFactors == 0
-raise unless zonemrtcalc.numExtensibleGroups == 0
-
-# There is also a batch add
-mrt_groups = mrt_weighting_factor_infos.map { |g| OpenStudio::Model::MRTWeightingFactor.new(g[0], g[1]) }
-zonemrtcalc.addMRTWeightingFactors(mrt_groups)
-raise unless zonemrtcalc.numberofMRTWeightingFactors == peoples.size
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,

--- a/model/simulationtests/zonemrtcalculation.rb
+++ b/model/simulationtests/zonemrtcalculation.rb
@@ -51,7 +51,6 @@ model.add_windows({ 'wwr' => 0.4,
                     'offset' => 1,
                     'application_type' => 'Above Floor' })
 
-# create the zone property user view factors by surface name object
 # There are a number of preconditions you must meet:
 # * All People objects should be assigned directly to a space,
 # * All spaces should be assigned to the same Thermal Zone.
@@ -69,6 +68,23 @@ airvelsch.setValue(0.5)
 # get all people in the zone
 peoples = []
 spaces.each do |space|
+  surfaces = []
+  sub_surfaces = []
+  space.surfaces.each do |surface|
+    surfaces << surface
+    surface.subSurfaces.each do |sub_surface|
+      sub_surfaces << sub_surface
+    end
+  end
+
+  surfaces = surfaces.uniq.sort_by { |s| s.name.to_s }
+  sub_surfaces = sub_surfaces.uniq.sort_by { |s| s.name.to_s }
+
+  comfortview = OpenStudio::Model::ComfortViewFactorAngles.new(model)
+  (surfaces + sub_surfaces).each do |surface|
+    comfortview.addAngleFactor(surface, 1.0 / (surfaces.size + sub_surfaces.size))
+  end
+
   definition1 = OpenStudio::Model::PeopleDefinition.new(model)
   definition1.setNumberofPeople(1.0)
   definition1.setMeanRadiantTemperatureCalculationType('EnclosureAveraged')
@@ -83,7 +99,8 @@ spaces.each do |space|
 
   definition2 = OpenStudio::Model::PeopleDefinition.new(model)
   definition2.setNumberofPeople(1.0)
-  definition2.setMeanRadiantTemperatureCalculationType('EnclosureAveraged') # SurfaceWeighted, AngleFactor not supported?
+  definition2.setMeanRadiantTemperatureCalculationType('SurfaceWeighted')
+  definition2.setSurfaceNameAngleFactorListName(surfaces[0])
   definition2.setThermalComfortModelType(0, 'Pierce')
 
   people2 = OpenStudio::Model::People.new(definition2)
@@ -92,6 +109,19 @@ spaces.each do |space|
   people2.setAirVelocitySchedule(airvelsch)
   people2.setSpace(space)
   peoples << people2
+
+  definition3 = OpenStudio::Model::PeopleDefinition.new(model)
+  definition3.setNumberofPeople(1.0)
+  definition3.setMeanRadiantTemperatureCalculationType('AngleFactor')
+  definition3.setSurfaceNameAngleFactorListName(comfortview)
+  definition3.setThermalComfortModelType(0, 'KSU')
+
+  people3 = OpenStudio::Model::People.new(definition3)
+  people3.setWorkEfficiencySchedule(workeffsch)
+  people3.setClothingInsulationSchedule(cloinssch)
+  people3.setAirVelocitySchedule(airvelsch)
+  people3.setSpace(space)
+  peoples << people3
 end
 
 # Extensible: MRT Weighting Factors for people

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -437,6 +437,19 @@ class ModelTests < Minitest::Test
     result = sim_test('coilsystem_cooling_water.osm')
   end
 
+  def test_comfortviewfactorangles_rb
+    result = sim_test('comfortviewfactorangles.rb')
+  end
+
+  def test_comfortviewfactorangles_py
+    result = sim_test('comfortviewfactorangles.py')
+  end
+
+  # TODO: To be added in the next official release after: 3.11.0
+  # def test_comfortviewfactorangles_osm
+  #   result = sim_test('comfortviewfactorangles.osm')
+  # end
+
   def test_coolingtowers_osm
     result = sim_test('coolingtowers.osm')
   end


### PR DESCRIPTION
Pull request overview
---------------------

Companion PR:
  - https://github.com/NatLabRockies/OpenStudio/pull/5650
  - ~Builds upon #232~

Link to the **Ubuntu 24.04 .deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.


----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.
<!---
> eg:
>
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following classes:
> * `AirTerminalSingleDuctConstantVolumeFourPipeBeam`
> * `CoilCoolingFourPipeBeam`
> * `CoilHeatingFourPipeBeam`
> * Additionally it explicitly tests for the existing class [TableMultiVariableLookUp](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/TableMultiVariableLookup.hpp)
-->

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [ ] with current develop (incude SHA):
         - [ ] The label `PendingOSM` has been added to this PR
         - [ ] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO: To be added in the next official release after: 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [ ] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [ ] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

 - [ ] **Object has been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
