### PR TITLE
Add an ENV Variable to force space load instances translation or not

### DIFF
--- a/test_helpers.rb
+++ b/test_helpers.rb
@@ -125,6 +125,16 @@ when 'false'
   $UseEplusSpaces = false
 end
 
+$UseSpaceLoadInstances = nil
+case ENV['USE_SPACE_LOAD_INSTANCES'].to_s.downcase
+when 'true'
+  puts 'USE_SPACE_LOAD_INSTANCES=true: Will translate SpaceLoads to the E+ ...:Instance / ...:Definition object pairs'
+  $UseSpaceLoadInstances = true
+when 'false'
+  puts 'USE_SPACE_LOAD_INSTANCES=false: Will force using the legacy (combined) SpaceLoad objects'
+  $UseSpaceLoadInstances = false
+end
+
 def get_cli_subcommand_from_env(sdk_version_str, debug: false)
   cur_sdk_version = Gem::Version.new(sdk_version_str)
   if debug
@@ -796,6 +806,13 @@ def sim_test(filename, options = {})
       extra_run_options += '--space-translation '
     else
       extra_run_options += '--no-space-translation '
+    end
+  end
+  if !$UseSpaceLoadInstances.nil?
+    if $UseSpaceLoadInstances
+      extra_run_options += '--space-load-instances '
+    else
+      extra_run_options += '--no-space-load-instances '
     end
   end
 


### PR DESCRIPTION
Pull request overview
---------------------

cf https://github.com/NatLabRockies/OpenStudio/pull/5651

This Pull Request is concerning:

 - [x] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.


----------------------------------------------------------------------------------------------------------

### Case 4: Other

You can now use `USE_SPACE_LOAD_INSTANCES=false` to turn off FT Translation to SpaceLoad Instances, eg it won't translate to `ElectricEquipment:Instance` + `ElectricEquipment:Definition` but to `ElectricEquipment`


----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
